### PR TITLE
Remove "/pr" as an Alias for /pick(random)

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -1501,7 +1501,6 @@ var commands = exports.commands = {
 		return this.sendReplyBox("Random number (1 - " + maxRoll + "): " + rand);
 	},
 
-	pr: 'pickrandom',
 	pick: 'pickrandom',
 	pickrandom: function (target, room, user) {
 		var options = target.split(',');


### PR DESCRIPTION
Should allow poll recalling with /pr, and save the hassles we had before.